### PR TITLE
Add AWS_DEFAULT_PROFILE support

### DIFF
--- a/senpai.zsh-theme
+++ b/senpai.zsh-theme
@@ -15,6 +15,8 @@ k8s_info() {
 aws_info() {
   if [ ! -z ${AWS_PROFILE} ]; then
     echo " %F{214}ⓦ ${AWS_PROFILE}%f"
+  elif [ ! -z ${AWS_DEFAULT_PROFILE} ]; then
+    echo " %F{214}ⓦ ${AWS_DEFAULT_PROFILE}%f"
   fi
 }
 


### PR DESCRIPTION
If _AWS_PROFILE_ is not set as an environment variable, _AWS_DEFAULT_PROFILE_ should also be checked as it is accepted by all CLIs that interact with AWS APIs.